### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ctest.yml
+++ b/.github/workflows/ctest.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/robinonsay/libjuno/security/code-scanning/2](https://github.com/robinonsay/libjuno/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the `contents: read` permission is sufficient, as the workflow only reads repository contents and uploads artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to each job individually. In this case, adding it at the root level is more efficient since both jobs (`build-and-test` and `build-and-test-posix`) require the same minimal permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
